### PR TITLE
Fix PHP Readme and .gitignore

### DIFF
--- a/php/.gitignore
+++ b/php/.gitignore
@@ -1,2 +1,2 @@
-vendor\
+vendor/
 composer.lock

--- a/php/README.md
+++ b/php/README.md
@@ -1,13 +1,9 @@
 # PHP version of Yatzy Refactoring Kata
 
-Make sure you have php and compose installed. Then in this directory:
+Make sure you have php and composer installed. Then in this directory:
 
     # To install php_unit in vendor:
     composer install
 
     # To run unit tests:
-    node_modules/mocha/bin/mocha
-    
-    # To run unit tests in watch mode:
-    node_modules/mocha/bin/mocha -w
-    
+    vendor/bin/phpunit YatzyTest.php    


### PR DESCRIPTION
Hello,
The way to execute unit tests is now described with phpunit (instead of mocha, the JS way).
The vendor directory was not correctly excluded in the .gitignore file.