### PR TITLE
The provided ruby code and accompanying tests won't pass for recent v…

### DIFF
--- a/ruby/yatzy.rb
+++ b/ruby/yatzy.rb
@@ -83,13 +83,13 @@ class Yatzy
     return s
   end
 
-  def initialize(d1, d2, d3, d4, _5)
+  def initialize(d1, d2, d3, d4, _five)
     @dice = [0]*5
     @dice[0] = d1
     @dice[1] = d2
     @dice[2] = d3
     @dice[3] = d4
-    @dice[4] = _5
+    @dice[4] = _five
   end
 
   def fours
@@ -161,10 +161,10 @@ class Yatzy
     end
   end
 
-  def self.four_of_a_kind( _1,  _2,  d3,  d4,  d5)
+  def self.four_of_a_kind( _one,  _two,  d3,  d4,  d5)
     tallies = [0]*6
-    tallies[_1-1] += 1
-    tallies[_2-1] += 1
+    tallies[_one-1] += 1
+    tallies[_two-1] += 1
     tallies[d3-1] += 1
     tallies[d4-1] += 1
     tallies[d5-1] += 1
@@ -220,11 +220,11 @@ class Yatzy
 
   def self.fullHouse( d1,  d2,  d3,  d4,  d5)
     tallies = []
-    _2 = false
+    _two = false
     i = 0
-    _2_at = 0
-    _3 = false
-    _3_at = 0
+    _two_at = 0
+    _three = false
+    _three_at = 0
 
     tallies = [0]*6
     tallies[d1-1] += 1
@@ -235,20 +235,20 @@ class Yatzy
 
     for i in Array 0..5
       if (tallies[i] == 2)
-        _2 = true
-        _2_at = i+1
+        _two = true
+        _two_at = i+1
       end
     end
 
     for i in Array 0..5
       if (tallies[i] == 3)
-        _3 = true
-        _3_at = i+1
+        _three = true
+        _three_at = i+1
       end
     end
 
-    if (_2 and _3)
-      return _2_at * 2 + _3_at * 3
+    if (_two and _three)
+      return _two_at * 2 + _three_at * 3
     else
       return 0
     end


### PR DESCRIPTION
The provided ruby code and accompanying tests won't pass for recent versions of Ruby.

```ruby
$ ruby test_yatzy.rb
test_yatzy.rb:1:in `require_relative': --> ~/Yatzy-Refactoring-Kata/ruby/yatzy.rb
_5 is reserved for numbered parameters
    1  class Yatzy
>  86    def initialize(d1, d2, d3, d4, _5)
>  93    end
  256  end
.... # similar errors elided for brevity
```
This is because the provided file follows the convention of the original problem, and uses underscore number in variables names: `_1`, `_2` etc.

Since Ruby 2.7 (released 2019), [numbered parameters have been reserved](https://bugs.ruby-lang.org/issues/4475) in the language as default block parameters.

To fix this, we rename the `_1` to `_one` and so on. Still inconsistent, though less likely to have been written accidentally. Also: still crying out for a refactor, and the tests still pass.

This also has the benefit of keeping the spirit of the original alive.

Fixes #40 