### PR TITLE
Remove outdated reference to py.test

### DIFF
--- a/python/test_yatzy1.py
+++ b/python/test_yatzy1.py
@@ -1,9 +1,6 @@
 from yatzy1 import Yatzy
 
 
-# These unit tests can be run using the py.test framework
-# available from http://pytest.org/
-
 def test_chance_scores_sum_of_all_dice():
     expected = 15
     actual = Yatzy.chance(2, 3, 4, 5, 1)


### PR DESCRIPTION
Installing pytest and running it is covered in the requirements.txt and the README.MD, so, perhaps, this comment is not needed anymore?